### PR TITLE
Update action versions in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,11 +30,11 @@ jobs:
         python-version: [3.12]
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     # Install dependencies
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     
@@ -49,7 +49,7 @@ jobs:
         
     # Upload the book's HTML as an artifact
     - name: Upload deployment artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v5
       with:
         path: site/_build/html
 
@@ -64,4 +64,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Updates to the latest versions of all GitHub actions used in deploy.yml:
- https://github.com/marketplace/actions/checkout
- https://github.com/marketplace/actions/setup-python
- https://github.com/marketplace/actions/upload-github-pages-artifact
- https://github.com/marketplace/actions/deploy-github-pages-site

Addresses [error with current deployment CI](https://github.com/UW-APL-SURP/aplsurp-python/actions/runs/27993298176) involving older action versions relying on Node 20 (https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)