### PR TITLE
Pin jupyter book <2, update GH actions versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,11 +30,11 @@ jobs:
         python-version: [3.12]
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     # Install dependencies
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     
@@ -49,7 +49,7 @@ jobs:
         
     # Upload the book's HTML as an artifact
     - name: Upload deployment artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v5
       with:
         path: site/_build/html
 
@@ -64,4 +64,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/environment.yml
+++ b/environment.yml
@@ -5,15 +5,15 @@ channels:
 dependencies:
   - python=3.12
   - pip
-  - jupyter-book
+  - jupyter-book<2
   - ipykernel
   - ghp-import
   - folium
   - matplotlib
   - numpy
   - pandas
+  # ocean data processing
   - ctd
-  - folium
   - gsw
   - seabird
   # - geopandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jupyter-book
+jupyter-book<2
 attrs
 nbclient
 matplotlib


### PR DESCRIPTION
Pin Jupyter Book to version 1.x (<2). Version 2 was released in late 2025 and requires a refactoring of the configuration files.

Updates to the latest versions of all GitHub actions used in `deploy.yml`:
- https://github.com/marketplace/actions/checkout
- https://github.com/marketplace/actions/setup-python
- https://github.com/marketplace/actions/upload-github-pages-artifact
- https://github.com/marketplace/actions/deploy-github-pages-site

Addresses [error with current deployment CI](https://github.com/UW-APL-SURP/aplsurp-python/actions/runs/27993298176) involving older action versions relying on Node 20 (https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)